### PR TITLE
feat: add markdown image lightbox preview

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=http://registry.npmmirror.com

--- a/src/components/markdown-image-preview.tsx
+++ b/src/components/markdown-image-preview.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type MarkdownImagePreviewProps = React.ImgHTMLAttributes<HTMLImageElement>;
+
+export default function MarkdownImagePreview({
+  alt,
+  className,
+  src,
+  ...props
+}: MarkdownImagePreviewProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const scrollY = window.scrollY;
+    const previousBodyOverflow = document.body.style.overflow;
+    const previousBodyPaddingRight = document.body.style.paddingRight;
+    const previousBodyPosition = document.body.style.position;
+    const previousBodyTop = document.body.style.top;
+    const previousBodyWidth = document.body.style.width;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = '100%';
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousBodyOverflow;
+      document.body.style.paddingRight = previousBodyPaddingRight;
+      document.body.style.position = previousBodyPosition;
+      document.body.style.top = previousBodyTop;
+      document.body.style.width = previousBodyWidth;
+      window.removeEventListener('keydown', handleKeyDown);
+      window.scrollTo(0, scrollY);
+    };
+  }, [isOpen]);
+
+  const openPreview = (event: React.MouseEvent<HTMLImageElement> | React.KeyboardEvent<HTMLImageElement>) => {
+    if (!src) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    setIsOpen(true);
+  };
+
+  const image = (
+    <img
+      {...props}
+      alt={alt}
+      src={src}
+      className={`${className ?? ''} cursor-zoom-in rounded-md transition hover:opacity-90`}
+      role="button"
+      tabIndex={0}
+      aria-label={alt ? `查看大图：${alt}` : '查看大图'}
+      onClick={openPreview}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          openPreview(event);
+        }
+      }}
+    />
+  );
+
+  if (!src) {
+    return image;
+  }
+
+  return (
+    <>
+      {image}
+      {isMounted && isOpen && createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm sm:p-6"
+          role="dialog"
+          aria-modal="true"
+          aria-label={alt ? `图片预览：${alt}` : '图片预览'}
+          onClick={() => setIsOpen(false)}
+        >
+          <button
+            type="button"
+            className="btn btn-circle btn-sm absolute right-3 top-3 bg-base-100/90 text-base-content shadow-md sm:right-5 sm:top-5"
+            aria-label="关闭图片预览"
+            onClick={() => setIsOpen(false)}
+          >
+            x
+          </button>
+          <img
+            src={src}
+            alt={alt}
+            className="max-h-[90vh] max-w-[95vw] cursor-zoom-out rounded-md object-contain shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          />
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/src/utils/posts-processor.tsx
+++ b/src/utils/posts-processor.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown, { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeUnwrapImages from 'rehype-unwrap-images';
 import { bundledLanguages, bundledThemes, createHighlighter } from 'shiki';
+import MarkdownImagePreview from '@/components/markdown-image-preview';
 
 export interface Post {
   id: string;
@@ -201,12 +202,16 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ source }: Ma
 
   // 自定义组件配置
   const components: Components = {
-    img: (attr) => (
-      <figure className="flex flex-col items-center">
-        <img {...attr} className="mx-auto max-h-64 max-w-72" />
-        {attr.alt && <figcaption className="text-sm text-gray-500 dark:text-gray-400 mt-1">{attr.alt}</figcaption>}
-      </figure>
-    ),
+    img: ({ node, ...imageAttr }) => {
+      void node;
+
+      return (
+        <figure className="flex flex-col items-center">
+          <MarkdownImagePreview {...imageAttr} className="mx-auto max-h-64 max-w-72" />
+          {imageAttr.alt && <figcaption className="text-sm text-gray-500 dark:text-gray-400 mt-1">{imageAttr.alt}</figcaption>}
+        </figure>
+      );
+    },
     // h2: ({ children }) => (
     //   <h2 className="text-xl font-bold py-2 border-b border-slate-400/30 mb-2">{children}</h2>
     // ),


### PR DESCRIPTION
## Summary
- add a client-side markdown image preview component with lightbox behavior
- replace inline markdown `<img>` rendering with clickable preview images and captions
- add `.npmrc` to prefer npmmirror for this mainland China server environment

## Verification
- did not run `npm` commands per request
- did not run build/lint/tests to avoid extra server load
